### PR TITLE
Revert "Overhaul of data exploration github site"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,253 +1,55 @@
 ---
-title: "Using the loc.gov JSON API"
-keywords: api tutorials homepage
+title: "About the loc.gov JSON API"
+keywords: api documentation homepage
 tags:
 sidebar: apidocs_sidebar
 permalink: index.html
-summary: Technical documentation of the loc.gov APIs can be found at [loc.gov/apis](https://www.loc.gov/apis/). This site supplements the documentation by providing tutorials and in-depth examples of working with various Library of Congress APIs. If you have ideas about what else the documentation or tutorials should cover, please email LC-Labs@loc.gov. 
-
+summary: The loc.gov API is a work in progress and subject to change. Once the API leaves Beta, we anticipate release of an official version of this documentation at loc.gov.
 ---
 
 ## Introduction
 
-The Library of Congress [data-exploration GitHub](https://github.com/LibraryOfCongress/data-exploration) includes several Jupyter notebooks and other tutorials on how to use the API, with example scripts. The tutorials are loosely categorized by topic. Under each heading, you can find details on what the tutorial documents contain, the assumed background knowledge, and possible applications of the code provided.
+The loc.gov JSON API provides structured data about Library of Congress collections. The API was originally designed to power the [loc.gov website](https://www.loc.gov), but in addition to providing HTML for the website it can provide a wealth of information in [JSON format](https://en.wikipedia.org/wiki/JSON).
+
+API stands for "application programming interface". You can write code that sends queries to the API in the form of URLs or web requests (like your browser makes) and get back responses that have structured data. That data, in [JSON format](https://en.wikipedia.org/wiki/JSON), is more easily used by software programs and in analysis tools. With an API, you can do things like:
+* dynamically include content from a website in your own website
+* send a query for data to feed [a Twitter bot](https://twitter.com/LoCMapBot)
+* create a dataset for analysis, visualization, or mapping.
+
+The loc.gov JSON API provides information about things you can find on the Library of Congress website:
+* items (books, archived websites, photos, and videos)
+* collections (thematic or otherwise grouped items that have been digitized)
+* images (thumbnails and higher resolution formats)
+
+
+There are other [specialized APIs and bulk downloads](https://labs.loc.gov/lc-for-robots) you may want to check out, too.
+
+The API does not include records from the library catalog (although items that have been digitized are retrievable). See the [MARC Open Access dataset](https://www.loc.gov/cds/products/marcDist.php) for bulk access to the catalog records up through 2014.
 
 {% include tip.html content="The API is a work in progress and things may change at any time. Fields may be added, deleted, or used in different ways, so make any code you write flexible and able to adjust to changes. Not every item is available via the API yet; some collections are still in process of being made available." %}
 
-Almost all of these documents are Jupyter notebooks, which is a programming environment that runs in a web browser. A notebook can contain both text in a markdown format and Python code that can be run directly as part of the workflow.
+## Base URL
 
-If this is your first time using Jupyter notebooks, here are a couple great tutorials online to help you install and set up the software:
+All URLs start with ```https://www.loc.gov/``` and need to include ```fo=json``` as a parameter to get JSON.
 
-* https://reproducible-science-curriculum.github.io/workshop-RR-Jupyter/setup/
-* https://programminghistorian.org/en/lessons/jupyter-notebooks
+No API key or authentication is required.
 
-Also, remember that the applications listed are only a few examples intended as a starting point! The possibilities are far wider. We're excited to see what you do with the collections. 
+## Requests
 
-{% include note.html content="This documentation is a resource to help people understand the API and make use of it. It’s intended to inspire creative uses of the Library of Congress collections. So, it's not comprehensive, but highlights the most relevant aspects. If you have ideas about what else this documentation should cover or anything else to make the API even more useful, let us know by emailing LC-Labs@loc.gov!" %}
+Get started by learning about [requests](requests.html), query parameters, and [pagination](pagination.html).
 
-## General Search and Query
+## Responses
 
-### [JSON API Overview](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/LOC.gov%20JSON%20API.ipynb)
+See [Responses](responses.html) for info about fields in search results and examples.
 
-An overview of how to retrieve information in a JSON format from the Library of Congress API. This tutorial sets a baseline for doing powerful data retrieval and visualization projects.
+## Tutorials
 
-**Background knowledge:**
-* Understand URLs for loc.gov API [requests](https://www.loc.gov/apis/json-and-yaml/requests/) and how to modify them
+* [Getting started with the loc.gov API](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/LOC.gov%20JSON%20API.ipynb) using Python.
+* [All tutorials](all-tutorials.html)
 
-**Applications:**
-* Get and visualize data
-* Show images from collections
-* Make cool projects like [this clock using collection item names](https://library-of-time.glitch.me/) and [this political cartoon visualizer](https://jeffreyshen19.github.io/political-cartoon-visualizer/) - for more inspiration, see the [experiments](https://labs.loc.gov/work/experiments/?st=gallery) that LC Labs has been working on!
+## How-to
 
-### [OpenSearch](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20web%20interface/OpenSearch.ipynb)
+* [How to work with sitemaps](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20Sitemaps%20API/Sitemap.ipynb)
 
-Brief guide to searching loc.gov directly from a web browser.
 
-**Background knowledge:** None
-
-**Applications:** Searching the website
-
-### [Sitemaps](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20Sitemaps%20API/Sitemap.ipynb)
-
-Describes Sitemaps and how to get information about the frequency of page updates.
-
-**Background knowledge:** None, but understanding the basics of [Sitemaps](https://www.sitemaps.org/) and [how the formatting works](https://www.sitemaps.org/protocol.html) is recommended
-
-**Applications:**
-* Determining how often collections or parts of the website are updated
-* Finding the number of items in a collection or sub-items on a page of the site
-
-## Images
-
-### [Accessing Images for Analysis](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/Accessing%20images%20for%20analysis.ipynb)
-
-How to access, display, and download images in bulk. Also provides information about what metadata is available and how to get particular details.
-
-This tutorial is for accessing images directly via the the API, so the images are generally smaller (150 px on one side) and low resolution. For accessing larger images that can be manipulated (size, rotation, crop, etc.), see the next tutorial, on IIIF.
-
-**Background knowledge:**
-* Understand URLs for loc.gov API [requests](https://www.loc.gov/apis/json-and-yaml/requests/) and how to modify them
-
-**Applications:**
-* Find URLs for images
-* Download images in bulk
-* Get information about the images, such as copyright and usage details, dates, locations, etc.
-
-### [IIIF](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20IIIF%20API/IIIF.ipynb)
-
-How to scale, rotate, reflect, crop, and otherwise manipulate images using the IIIF API.
-
-IIIF stands for the International Image Interoperability Framework. It is a standardized way to get images that is used by various libraries, museums, digital archives, etc.
-
-**Background knowledge:**
-* Where to find the IIIF URLs (can be found in image metadata accessed via the JSON API)
-* (optional) Details of [IIIF URL structure](https://iiif.io/api/image/2.1/#table-of-contents)
-
-**Applications:**
-* Get higher resolution images and manipulate them
-* Display images - individually or in galleries
-* Can also be done in bulk
-
-### [Image Color Analysis](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/Dominant%20colors.ipynb)
-
-How to find and analyze the colors in an image. This tutorial uses [k-means clustering](https://jakevdp.github.io/PythonDataScienceHandbook/05.11-k-means.html) to analyze and group the pixel values into 6 colors per image, but you can adjust that as needed.
-
-**Background knowledge:**
-* Using [links in HTML](https://www.w3schools.com/tags/att_a_href.asp)
-* How to create an [SVG rectangle in HTML](https://www.w3schools.com/graphics/svg_rect.asp)
-* (optional - recommended) Color codes for web - [RGB vs. Hex](https://goedemorgenwp.com/make-site-colorful-color-use-hex-vs-rgb/)
-
-**Applications:**
-* Visualize [colors in Library of Congress collections images](https://loc-colors.glitch.me/)
-* Categorize or search images by color
-
->**[Downloading Monographs as Images](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/Downloading_Monographs_as_Images_in_Rosenwald_Collection/Downloading%20Monographs%20as%20Images%20in%20Rosenwald%20Collection.ipynb)**
-
-Similar to the Accessing Images for Data Analysis notebook — provides code for accessing and downloading images specifically from the [Lessing J. Rosenwald Collection](https://www.loc.gov/rr/rarebook/rosenwald.html).
-
-See background knowledge and applications for the accessing images notebook.
-
-## Geographic Data and Maps
-
-### [Extracting Location Data](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/Extracting%20location%20data%20for%20geovisualization.ipynb)
-
-Demonstrates how to retrieve geographic data (latitude and longitude) and plot it onto a map. This tutorial focuses on items in the Historic American Engineering Record (HAER). The way that geographic data is stored across collections does vary, so some collections may require more data cleaning and manipulation before doing geographic visualizations.
-
-**Background knowledge:**
-* Understand URLs for loc.gov API [requests](https://www.loc.gov/apis/json-and-yaml/requests/) and how to modify them
-* (optional) Python [folium mapping](https://python-visualization.github.io/folium/modules.html#module-folium.map)
-* (optional) Python [pandas dataframe](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html)
-
-**Applications:**
-* Map item locations
-* Analyze geographic data and connect it to other information, such as date
-* Compare geographies across collections
-
-### [Maps Downloading and Querying](https://github.com/LibraryOfCongress/data-exploration/blob/master/maps/maps-downloading-querying.ipynb)
-
-How to query and download cartographic material. Includes:
-* performing bulk downloads of cartographic materials using the loc.gov API and Python
-* crafting advanced API queries for map content
-* performing post-query filtering
-
-**Background knowledge:** None, though it may be useful to have some familiarity with Python
-
-**Applications:**
-* Download and display images from the collections
-* Create sets of images that can be used in a number of other applications
-
-### [Maps Metadata](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/maps/maps-analyzing-metadata.ipynb)
-
-How to find, analyze, and visualize cartographic metadata. This tutorial focuses on metadata associated with the files in the Maps Downloading and Querying tutorial as well as items in the Sanborn Maps collection.
-
-**Background knowledge:**
-* How to [install a python package using pip](https://www.w3schools.com/python/python_pip.asp) - or some other package manager
-
-**Applications:**
-* Search for items within a collection/dataset that have particular locations, dates, etc.
-* Analyze the different parts of the metadata (longest/shortest/average item length, most common dates or locations)
-* Create charts with the data that compare all of the items
-
-## Historic Newspapers
-
-### [Chronicling America](https://github.com/LibraryOfCongress/data-exploration/blob/master/Chronicling%20America%20API/ChronAm%20API%20Samples.ipynb)
-
-The Chronicling America database also has an API that functions similarly to the wider loc.gov API. Its URLs start with https://www.chroniclingamerica.loc.gov/ instead of https://www.loc.gov/ but the endings for querying are the same.
-
-This tutorial provides an introduction to what information is available via the API — one notable difference is that since this collection consists of newspaper pages, you can retrieve the text from the page (collected using [OCR](https://en.wikipedia.org/wiki/Optical_character_recognition)) via the API. It also covers searching for keywords and analyzing data from bulk records.
-
-**Background knowledge:**
-* Understand URLs for loc.gov API [requests](https://www.loc.gov/apis/json-and-yaml/requests/) and how to modify them
-
-**Applications:**
-* Visualize search results on a map
-* Find certain quotes through time
-* Do historical research
-* See [these projects](https://blogs.loc.gov/thesignal/2016/08/the-neh-chronicling-america-challenge-using-big-data-to-ask-big-questions/) for more!
-
-### [Chronicling America CSV](https://github.com/LibraryOfCongress/data-exploration/tree/master/chronam_all_digitized)
-
-The Python script here creates a csv file of all of the digitized titles in Chronicling America, with their associated metadata.
-
-**Background knowledge:**
-* [Command line basics](https://www.codecademy.com/articles/command-line-commands#:~:text=The%20command%20line%20is%20a,or%20Finder%20on%20Mac%20OS.)
-* Need Python 3 installed - basic understanding of how Python and the API work needed for modification
-
-**Applications:** The produced csv can be used for a number of different data analysis and [visualization](https://www.loc.gov/ndnp/data-visualizations/) applications. See the Memegenerator and GIPHY tutorials for more on how to use Python code to analyze data in csv file formats.
-
-### [Chronicling America Issue Counts CSV](https://github.com/LibraryOfCongress/data-exploration/tree/master/chronam_issue_counts)
-
-These scripts create csv files where each row contains the state name, year, and the number of newspaper issues in the Chronicling America database available in that state and year. Each script does this for one state.
-
-See above (Chronicling America CSV) for background knowledge needed and potential applications.
-
-## Other
-
-### [Memegenerator Metadata](https://github.com/LibraryOfCongress/data-exploration/blob/master/Data%20Sets/Web%20Archives/getting_started_with_memegenerator.ipynb)
-
-Introduction to csv data analysis in Python using the Memgenerator dataset from [this page](https://labs.loc.gov/work/experiments/webarchive-datasets/). Shows how to:
-* find column headers to see what data is available
-* count occurrences within the dataset
-* visualize data in a bar graph
-* retrieve and display images
-
-**Background knowledge:** None, though it may be useful to have some familiarity with Python
-
-**Applications:**
-* Exploring memes
-* Finding [top 10s and other statistics](https://blogs.loc.gov/thesignal/2018/10/data-mining-memes-in-the-digital-culture-web-archive/) in a dataset
-* Data analysis and visualization for any dataset
-
-### [GIPHY.com Metadata](https://github.com/LibraryOfCongress/data-exploration/blob/master/Data%20Sets/Web%20Archives/getting_started_with_giphy.ipynb)
-
-Slightly more advanced csv data analysis in Python using the [GIPHY.com dataset taken from this page](https://labs.loc.gov/work/experiments/webarchive-datasets/). Shows how to:
-* Get dates for the GIFs
-* Group and visualize the dates
-* Find the GIF file sizes
-* Search the titles in the dataset
-* Download all of the GIFs
-
-**Background knowledge:** some familiarity with Python and/or data analysis - the Memegenerator tutorial is a good place to start
-
-**Applications:**
-* Exploring GIFs
-* Searching through datasets
-* Data analysis and visualization for any dataset
-
-### [Accessing and Remixing Sound](https://github.com/LibraryOfCongress/data-exploration/blob/master/Data%20Sets/Web%20Archives/loc_goes_lofi.ipynb)
-
-Provides code for selecting random audio segments and combining them together. Assumes that users have already downloaded the [audio files](https://s3.us-east-2.amazonaws.com/lclabspublicdata/lcwa_gov_audio_data.zip) into the same folder as this notebook. The dataset includes 1000 randomly selected audio clips. For more information on how this dataset was generated, see the [README](https://s3.us-east-2.amazonaws.com/lclabspublicdata/lcwa_gov_audio_README.txt).
-
-**Background knowledge:**
-* Python:
-  * [Importing packages](https://docs.python.org/3/reference/import.html)
-  * [Defining functions](https://www.w3schools.com/python/python_functions.asp)
-  * Using the [pydub package](https://github.com/jiaaro/pydub)
-  * (optional) Using the [glob](https://docs.python.org/3/library/glob.html), [re](https://docs.python.org/3/howto/regex.html), and [random](https://docs.python.org/3/library/random.html) packages
-
-**Applications:**
-* Create remixed audio
-* Manipulate existing audio files
-* Build interactive audio sampling tools, like [this](https://citizen-dj.labs.loc.gov/)
-
-### [American Folklife Center Scripts](https://github.com/LibraryOfCongress/data-exploration/tree/master/americanfolklifecenter)
-
-Includes 2 bash scripts, [reportmd.sh](https://github.com/LibraryOfCongress/data-exploration/blob/master/Processing%20Scripts/americanfolklifecenter/reportmd.sh) and [processfiles.sh](https://github.com/LibraryOfCongress/data-exploration/blob/master/Processing%20Scripts/americanfolklifecenter/processfiles.sh). These scripts intend to make processing and data analysis easier by automating some of the initial steps. They can be run on any command line interface (i.e. Terminal for macOS, PowerShell or Command prompt for Windows), and the script will prompt user inputs.
-
-Reportmd - Reports collection records out into CSV, GZ, and XML files.
-
-Processfiles - Does processing to clean up files, including batch file renaming, deleting files, and flattening directories.
-
-**Note:** These scripts are complex and require background knowledge to fully understand. However, they can be run and used without that background.
-
-**Background knowledge:**
-* Bash scripts:
-  * [one tutorial](https://www.taniarascia.com/how-to-create-and-use-bash-scripts/)
-  * [another tutorial](https://ryanstutorials.net/bash-scripting-tutorial/bash-script.php)
-
-**Applications:**
-* Get data into a different file format
-* Automate some data cleaning/processing
-* Can be modified to work for other datasets and collections outside of the American Folklife Center
-
-
+{% include note.html content="This documentation is a resource to help people understand the API and make use of it. It’s intended to inspire creative uses of the Library of Congress collection. So, it's not comprehensive, but highlights the most relevant aspects. If you have ideas about what else this documentation should cover or anything else to make the API even more useful, let us know!" %}

--- a/docs/pages/apidocs/all-tutorials.md
+++ b/docs/pages/apidocs/all-tutorials.md
@@ -1,0 +1,242 @@
+---
+title: "Available Tutorials"
+keywords: tutorial, how-to, api, Jupyter, json
+tags:
+sidebar: apidocs_sidebar
+permalink: all-tutorials.html
+summary: The data-exploration GitHub includes several Jupyter notebooks and other files that contain tutorials on how to use the API, with example scripts. The tutorials are loosely categorized by topic. Under each heading, you can find details on what the tutorial documents contain, the assumed background knowledge, and possible applications of the code provided.
+---
+
+Almost all of these documents are Jupyter notebooks, which is a programming environment that runs in a web browser. A notebook can contain both text in a markdown format and Python code that can be run directly as part of the workflow.
+
+If this is your first time using Jupyter notebooks, here are a couple great tutorials online to help you install and set up the software:
+
+* https://reproducible-science-curriculum.github.io/workshop-RR-Jupyter/setup/
+* https://programminghistorian.org/en/lessons/jupyter-notebooks
+
+Also, remember that the applications listed are only a few examples intended as a starting point! The possibilities are far wider. We're excited to see what you do with the collections. If you have ideas about how to make the API more useful or more topics that you want us to cover in the documentation, please let us know!
+
+## General Search and Query
+
+### [JSON API Overview](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/LOC.gov%20JSON%20API.ipynb)
+
+An overview of how to retrieve information in a JSON format from the Library of Congress API. This tutorial sets a baseline for doing powerful data retrieval and visualization projects.
+
+**Background knowledge:**
+* Understand URLs for loc.gov API [requests](requests.html) and how to modify them
+
+**Applications:**
+* Get and visualize data
+* Show images from collections
+* Make cool projects like [this clock using collection item names](https://library-of-time.glitch.me/) and [this political cartoon visualizer](https://jeffreyshen19.github.io/political-cartoon-visualizer/) - for more inspiration, see the [experiments](https://labs.loc.gov/work/experiments/?st=gallery) that LC Labs has been working on!
+
+### [OpenSearch](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20web%20interface/OpenSearch.ipynb)
+
+Brief guide to searching loc.gov directly from a web browser.
+
+**Background knowledge:** None
+
+**Applications:** Searching the website
+
+### [Sitemaps](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20Sitemaps%20API/Sitemap.ipynb)
+
+Describes Sitemaps and how to get information about the frequency of page updates.
+
+**Background knowledge:** None, but understanding the basics of [Sitemaps](https://www.sitemaps.org/) and [how the formatting works](https://www.sitemaps.org/protocol.html) is recommended
+
+**Applications:**
+* Determining how often collections or parts of the website are updated
+* Finding the number of items in a collection or sub-items on a page of the site
+
+## Images
+
+### [Accessing Images for Analysis](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/Accessing%20images%20for%20analysis.ipynb)
+
+How to access, display, and download images in bulk. Also provides information about what metadata is available and how to get particular details.
+
+This tutorial is for accessing images directly via the the API, so the images are generally smaller (150 px on one side) and low resolution. For accessing larger images that can be manipulated (size, rotation, crop, etc.), see the next tutorial, on IIIF.
+
+**Background knowledge:**
+* Understand URLs for loc.gov API [requests](requests.html) and how to modify them
+
+**Applications:**
+* Find URLs for images
+* Download images in bulk
+* Get information about the images, such as copyright and usage details, dates, locations, etc.
+
+### [IIIF](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20IIIF%20API/IIIF.ipynb)
+
+How to scale, rotate, reflect, crop, and otherwise manipulate images using the IIIF API.
+
+IIIF stands for the International Image Interoperability Framework. It is a standardized way to get images that is used by various libraries, museums, digital archives, etc.
+
+**Background knowledge:**
+* Where to find the IIIF URLs (can be found in image metadata accessed via the JSON API)
+* (optional) Details of [IIIF URL structure](https://iiif.io/api/image/2.1/#table-of-contents)
+
+**Applications:**
+* Get higher resolution images and manipulate them
+* Display images - individually or in galleries
+* Can also be done in bulk
+
+### [Image Color Analysis](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/Dominant%20colors.ipynb)
+
+How to find and analyze the colors in an image. This tutorial uses [k-means clustering](https://jakevdp.github.io/PythonDataScienceHandbook/05.11-k-means.html) to analyze and group the pixel values into 6 colors per image, but you can adjust that as needed.
+
+**Background knowledge:**
+* Using [links in HTML](https://www.w3schools.com/tags/att_a_href.asp)
+* How to create an [SVG rectangle in HTML](https://www.w3schools.com/graphics/svg_rect.asp)
+* (optional - recommended) Color codes for web - [RGB vs. Hex](https://goedemorgenwp.com/make-site-colorful-color-use-hex-vs-rgb/)
+
+**Applications:**
+* Visualize [colors in Library of Congress collections images](https://loc-colors.glitch.me/)
+* Categorize or search images by color
+
+>**[Downloading Monographs as Images](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/Downloading_Monographs_as_Images_in_Rosenwald_Collection/Downloading%20Monographs%20as%20Images%20in%20Rosenwald%20Collection.ipynb)**
+
+Similar to the Accessing Images for Data Analysis notebook — provides code for accessing and downloading images specifically from the [Lessing J. Rosenwald Collection](https://www.loc.gov/rr/rarebook/rosenwald.html).
+
+See background knowledge and applications for the accessing images notebook.
+
+## Geographic Data and Maps
+
+### [Extracting Location Data](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/Extracting%20location%20data%20for%20geovisualization.ipynb)
+
+Demonstrates how to retrieve geographic data (latitude and longitude) and plot it onto a map. This tutorial focuses on items in the Historic American Engineering Record (HAER). The way that geographic data is stored across collections does vary, so some collections may require more data cleaning and manipulation before doing geographic visualizations.
+
+**Background knowledge:**
+* Understand URLs for loc.gov API [requests](requests.html) and how to modify them
+* (optional) Python [folium mapping](https://python-visualization.github.io/folium/modules.html#module-folium.map)
+* (optional) Python [pandas dataframe](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html)
+
+**Applications:**
+* Map item locations
+* Analyze geographic data and connect it to other information, such as date
+* Compare geographies across collections
+
+### [Maps Downloading and Querying](https://github.com/LibraryOfCongress/data-exploration/blob/master/maps/maps-downloading-querying.ipynb)
+
+How to query and download cartographic material. Includes:
+* performing bulk downloads of cartographic materials using the loc.gov API and Python
+* crafting advanced API queries for map content
+* performing post-query filtering
+
+**Background knowledge:** None, though it may be useful to have some familiarity with Python
+
+**Applications:**
+* Download and display images from the collections
+* Create sets of images that can be used in a number of other applications
+
+### [Maps Metadata](https://github.com/LibraryOfCongress/data-exploration/blob/master/loc.gov%20JSON%20API/maps/maps-analyzing-metadata.ipynb)
+
+How to find, analyze, and visualize cartographic metadata. This tutorial focuses on metadata associated with the files in the Maps Downloading and Querying tutorial as well as items in the Sanborn Maps collection.
+
+**Background knowledge:**
+* How to [install a python package using pip](https://www.w3schools.com/python/python_pip.asp) - or some other package manager
+
+**Applications:**
+* Search for items within a collection/dataset that have particular locations, dates, etc.
+* Analyze the different parts of the metadata (longest/shortest/average item length, most common dates or locations)
+* Create charts with the data that compare all of the items
+
+## Historic Newspapers
+
+### [Chronicling America](https://github.com/LibraryOfCongress/data-exploration/blob/master/Chronicling%20America%20API/ChronAm%20API%20Samples.ipynb)
+
+The Chronicling America database also has an API that functions similarly to the wider loc.gov API. Its URLs start with https://www.chroniclingamerica.loc.gov/ instead of https://www.loc.gov/ but the endings for querying are the same.
+
+This tutorial provides an introduction to what information is available via the API — one notable difference is that since this collection consists of newspaper pages, you can retrieve the text from the page (collected using [OCR](https://en.wikipedia.org/wiki/Optical_character_recognition)) via the API. It also covers searching for keywords and analyzing data from bulk records.
+
+**Background knowledge:**
+* Understand URLs for loc.gov API [requests](requests.html) and how to modify them
+
+**Applications:**
+* Visualize search results on a map
+* Find certain quotes through time
+* Do historical research
+* See [these projects](https://blogs.loc.gov/thesignal/2016/08/the-neh-chronicling-america-challenge-using-big-data-to-ask-big-questions/) for more!
+
+### [Chronicling America CSV](https://github.com/LibraryOfCongress/data-exploration/tree/master/chronam_all_digitized)
+
+The Python script here creates a csv file of all of the digitized titles in Chronicling America, with their associated metadata.
+
+**Background knowledge:**
+* [Command line basics](https://www.codecademy.com/articles/command-line-commands#:~:text=The%20command%20line%20is%20a,or%20Finder%20on%20Mac%20OS.)
+* Need Python 3 installed - basic understanding of how Python and the API work needed for modification
+
+**Applications:** The produced csv can be used for a number of different data analysis and [visualization](https://www.loc.gov/ndnp/data-visualizations/) applications. See the Memegenerator and GIPHY tutorials for more on how to use Python code to analyze data in csv file formats.
+
+### [Chronicling America Issue Counts CSV](https://github.com/LibraryOfCongress/data-exploration/tree/master/chronam_issue_counts)
+
+These scripts create csv files where each row contains the state name, year, and the number of newspaper issues in the Chronicling America database available in that state and year. Each script does this for one state.
+
+See above (Chronicling America CSV) for background knowledge needed and potential applications.
+
+## Other
+
+### [Memegenerator Metadata](https://github.com/LibraryOfCongress/data-exploration/blob/master/Data%20Sets/Web%20Archives/getting_started_with_memegenerator.ipynb)
+
+Introduction to csv data analysis in Python using the Memgenerator dataset from [this page](https://labs.loc.gov/work/experiments/webarchive-datasets/). Shows how to:
+* find column headers to see what data is available
+* count occurrences within the dataset
+* visualize data in a bar graph
+* retrieve and display images
+
+**Background knowledge:** None, though it may be useful to have some familiarity with Python
+
+**Applications:**
+* Exploring memes
+* Finding [top 10s and other statistics](https://blogs.loc.gov/thesignal/2018/10/data-mining-memes-in-the-digital-culture-web-archive/) in a dataset
+* Data analysis and visualization for any dataset
+
+### [GIPHY.com Metadata](https://github.com/LibraryOfCongress/data-exploration/blob/master/Data%20Sets/Web%20Archives/getting_started_with_giphy.ipynb)
+
+Slightly more advanced csv data analysis in Python using the [GIPHY.com dataset taken from this page](https://labs.loc.gov/work/experiments/webarchive-datasets/). Shows how to:
+* Get dates for the GIFs
+* Group and visualize the dates
+* Find the GIF file sizes
+* Search the titles in the dataset
+* Download all of the GIFs
+
+**Background knowledge:** some familiarity with Python and/or data analysis - the Memegenerator tutorial is a good place to start
+
+**Applications:**
+* Exploring GIFs
+* Searching through datasets
+* Data analysis and visualization for any dataset
+
+### [Accessing and Remixing Sound](https://github.com/LibraryOfCongress/data-exploration/blob/master/Data%20Sets/Web%20Archives/loc_goes_lofi.ipynb)
+
+Provides code for selecting random audio segments and combining them together. Assumes that users have already downloaded the [audio files](https://s3.us-east-2.amazonaws.com/lclabspublicdata/lcwa_gov_audio_data.zip) into the same folder as this notebook. The dataset includes 1000 randomly selected audio clips. For more information on how this dataset was generated, see the [README](https://s3.us-east-2.amazonaws.com/lclabspublicdata/lcwa_gov_audio_README.txt).
+
+**Background knowledge:**
+* Python:
+  * [Importing packages](https://docs.python.org/3/reference/import.html)
+  * [Defining functions](https://www.w3schools.com/python/python_functions.asp)
+  * Using the [pydub package](https://github.com/jiaaro/pydub)
+  * (optional) Using the [glob](https://docs.python.org/3/library/glob.html), [re](https://docs.python.org/3/howto/regex.html), and [random](https://docs.python.org/3/library/random.html) packages
+
+**Applications:**
+* Create remixed audio
+* Manipulate existing audio files
+* Build interactive audio sampling tools, like [this](https://citizen-dj.labs.loc.gov/)
+
+### [American Folklife Center Scripts](https://github.com/LibraryOfCongress/data-exploration/tree/master/americanfolklifecenter)
+
+Includes 2 bash scripts, [reportmd.sh](https://github.com/LibraryOfCongress/data-exploration/blob/master/Processing%20Scripts/americanfolklifecenter/reportmd.sh) and [processfiles.sh](https://github.com/LibraryOfCongress/data-exploration/blob/master/Processing%20Scripts/americanfolklifecenter/processfiles.sh). These scripts intend to make processing and data analysis easier by automating some of the initial steps. They can be run on any command line interface (i.e. Terminal for macOS, PowerShell or Command prompt for Windows), and the script will prompt user inputs.
+
+Reportmd - Reports collection records out into CSV, GZ, and XML files.
+
+Processfiles - Does processing to clean up files, including batch file renaming, deleting files, and flattening directories.
+
+**Note:** These scripts are complex and require background knowledge to fully understand. However, they can be run and used without that background.
+
+**Background knowledge:**
+* Bash scripts:
+  * [one tutorial](https://www.taniarascia.com/how-to-create-and-use-bash-scripts/)
+  * [another tutorial](https://ryanstutorials.net/bash-scripting-tutorial/bash-script.php)
+
+**Applications:**
+* Get data into a different file format
+* Automate some data cleaning/processing
+* Can be modified to work for other datasets and collections outside of the American Folklife Center

--- a/docs/pages/apidocs/pagination.md
+++ b/docs/pages/apidocs/pagination.md
@@ -1,0 +1,122 @@
+---
+title: Pagination
+keywords: pagination, pages, query, results, api 
+last_updated: Dec 19, 2017
+tags: 
+summary: "The API returns items in pages or results, rather than all of the results at once. "
+sidebar: apidocs_sidebar
+permalink: pagination.html
+folder: apidocs
+---
+
+The default number of results per response (or "page") is 25. You can change how many are in each response by using the ```c``` parameter in your request, for example ```c=100```. Be considerate and keep your count to a reasonable number. Your response may take longer to return if you set it too high. 
+
+The ```pagination``` section of the response has the information you’ll need to understand which page of results you’re on. One way to get the next page of results is to use the URL in the ```next``` field. When there are no more pages, it will be null. 
+
+{% include tip.html content="You may see a pages section in the JSON returned for a query but that’s for a different purpose. Be sure to use the pagination section." %}
+
+<table>
+  <tr>
+    <td><strong>Field</strong> (within "pagination")</td>
+    <td><strong>Description</strong></td>
+    <td><strong>Example</strong></td>
+  </tr>
+  <tr>
+    <td>from</td>
+    <td>Index number of the first result item in this page of results.</td>
+    <td>26</td>
+  </tr>
+  <tr>
+    <td>to</td>
+    <td>Index number of the last result in this page of results. </td>
+    <td>50</td>
+  </tr>
+  <tr>
+    <td>results</td>
+    <td>Index numbers of the result items in this page.</td>
+    <td>“26 - 50”</td>
+  </tr>
+  <tr>
+    <td>last</td>
+    <td>URL of the last page of results in the whole set of results pages.</td>
+    <td>"https://www.loc.gov/search/?q=giraffe&sp=5&fo=json”</td>
+  </tr>
+  <tr>
+    <td>of</td>
+    <td>Total number of items in the results. </td>
+    <td>318</td>
+  </tr>
+  <tr>
+    <td>previous</td>
+    <td>URL of the preceding page of results. Will be null when this is the first page.</td>
+    <td>"https://www.loc.gov/search/?q=giraffe&sp=1&fo=json",</td>
+  </tr>
+  <tr>
+    <td>next</td>
+    <td>URL of the next page of results. Will be null when there are not more pages.</td>
+    <td>"https://www.loc.gov/search/?q=giraffe&sp=3&fo=json"</td>
+  </tr>
+  <tr>
+    <td>perpage</td>
+    <td>Number of result items on each page. </td>
+    <td>25</td>
+  </tr>
+  <tr>
+    <td>total</td>
+    <td>Total number of pages available.</td>
+    <td>5</td>
+  </tr>
+  <tr>
+    <td>current</td>
+    <td>Page number you are currently on.</td>
+    <td>2</td>
+  </tr>
+</table>
+
+**Example:**
+
+``https://www.loc.gov/collections/national-child-labor-committee/?sp=2&c=100&fo=json``
+
+Pagination section of JSON in a search result response:
+
+```
+{
+  "pagination": {
+    "from": 1,
+    "results": "1 - 25",
+    "last": "https://www.loc.gov/collections/civil-war-maps/?sp=4&fo=json",
+    "total": 94,
+    "previous": null,
+    "perpage": 25,
+    "perpage_options": [
+      25,
+      50,
+      100,
+      150
+    ],
+    "of": 2335,
+    "next": "https://www.loc.gov/collections/civil-war-maps/?sp=2&fo=json",
+    "current": 1,
+    "to": 25,
+    "page_list": [
+      {
+        "url": null,
+        "number": 1
+      },
+      {
+        "url": "https://www.loc.gov/collections/civil-war-maps/?sp=2&fo=json",
+        "number": 2
+      },
+      {
+        "url": "https://www.loc.gov/collections/civil-war-maps/?sp=3&fo=json",
+        "number": 3
+      },
+      {
+        "url": "https://www.loc.gov/collections/civil-war-maps/?sp=4&fo=json",
+        "number": "..."
+      }
+    ],
+    "first": null
+  }
+}
+```

--- a/docs/pages/apidocs/requests.md
+++ b/docs/pages/apidocs/requests.md
@@ -1,0 +1,164 @@
+---
+title: Requests
+keywords: requests, query, api 
+last_updated: Dec 19, 2017
+tags: 
+summary: "A request is a URL with query parameters."
+sidebar: apidocs_sidebar
+permalink: requests.html
+folder: apidocs
+---
+
+## Base URL
+
+All URLs start with ```https://www.loc.gov/``` and should include ```fo=json``` as a parameter to get JSON
+
+No API key or authentication is required. 
+
+## Searching
+
+Get a set of items back by using one of these search endpoints. You can add parameters to the end of any of them, and should always include ```fo=json```.
+
+{%  include tip.html content="Because the API also powers the website, you can use the search box on the loc.gov website to understand how different search parameters affect results." %}
+
+
+### /search/?
+
+Searches everything on the www.loc.gov website. Includes items in the collection, legislation, web pages, blog posts, and press releases. 
+
+Example: ```https://www.loc.gov/search/?q=baseball&fo=json```
+
+The API does not include records from the library catalog (although items that have been digitized are retrievable). See the [MARC Open Access dataset](https://www.loc.gov/cds/products/marcDist.php) for bulk access to the catalog records up through 2014. 
+
+### /collections/{name of collection}?
+
+Searches within a specified collection. The name of the collection needs to be in "slug" form, which is words separated by hyphens. For example: abraham-lincoln-papers or baseball-cards.  You can find the collection’s name by searching the website. 
+
+<!--{% include tip.html content="Most, but not all collections are queryable via the API. Here’s how you can check which collections are online and available to query." %}" -->
+
+**Example:** ```https://www.loc.gov/collections/civil-war-maps?fo=json```
+
+### /{format}/?
+
+Searches for items which have a specified original format. Possible values include:
+
+* maps:	```maps```
+* audio recordings:	```audio```
+* photo, print, drawing: ```photos```
+* manuscripts/mixed material: ```manuscripts```
+* newspapers:	```newspapers```
+* film, videos: ```film-and-videos```
+* printed music, such as sheet music: ```notated-music```
+* archived websites: ```websites```
+
+**Example:** ```https://www.loc.gov/maps/?q=civil war&fo=json```
+
+
+## Common parameters
+
+Always include ```fo=json``` in your URL so that you get JSON, not HTML.
+
+<table>
+  <tr>
+    <td style="white-space: nowrap;"><strong>Parameter</strong></td>
+    <td><strong>Description</strong></td>
+    <td><strong>Examples</strong></td>
+  </tr>
+  <tr>
+    <td>q</td>
+    <td>query parameter<br />Does a keyword search in the metadata and any available full text including video transcripts</td>
+    <td>q=kittens</td>
+  </tr>
+  <tr>
+    <td>fa</td>
+    <td>filter or facet<br />
+      <p>takes the format filter-name:value<br />
+      multiple filters can be used by separating them with a pipe character: |</p>
+      
+      <p>Available filters/facets include:</p>
+      <p><strong>location</strong></p>
+      <p><strong>subject</strong></p>
+      <p><strong>original-format</strong></p>
+      <p>Many formats are also available as endpoints (e.g. /maps/). Those that are ONLY available using the filters/facets parameter include:</p>
+        original-format:sound recording<br />
+        original-format:legislation<br />
+        original-format:periodical<br />
+        original-format:personal narrative<br />
+        original-format:software,e-resource<br />
+        original-format:3d object<br />
+
+      <p><strong>partof</strong></p>
+      <p>Collections, divisions, and units in the Library of Congress. Most are also available using the collections endpoint. See <a href="https://www.loc.gov/search/index/partof/">Part ofs</a> for a list.</p>
+      <p><strong>contributor</strong></p>
+    </td>
+    <td style="white-space: nowrap;"><p>fa=location:ohio</p>
+      <p>fa=location:yellowstone national park</p>
+      <p>fa=subject:meterology</p>
+      <p>fa=original-format:periodical|subject:wildlife</p>
+      <p>fa=partof:performing arts encyclopedia</p>
+      <p>fa=contributor:lange, dorothea</p>
+    </td>
+  </tr>
+  <tr>
+    <td>c</td>
+    <td>results per page
+default is 25</td>
+    <td>c=50</td>
+  </tr>
+  <tr>
+    <td>sp</td>
+    <td>page in results (results are returned in pages of 25 items unless specified using the c parameter)
+      The first page is sp=1.</td>
+    <td>sp=2</td>
+  </tr>
+  <tr>
+    <td>at</td>
+    <td>attributes to return in the results
+      <p>This is helpful for removing extraneous information from the results, such as more_like_this and related_items. You can specify 
+        elements to exclude using at!=</p></td>
+    <td>at=item<br />at=item,resources,reproductions<br />at!=more_like_this</td>
+  </tr>
+  <tr>
+    <td>sb</td>
+    <td>sort field
+      <p>Available sort options include:</p>
+        date (earliest to latest)<br />
+        date_desc (latest to earliest)<br />
+        title_s (by title)<br />
+        title_s_desc (reverse by title)<br />
+        shelf_id (call number/physical location)<br />
+        shelf_id_desc (reverse by call number/physical location)<br />
+    </td>
+    <td>sb=date_desc<br />
+    sb=shelf_id</td>
+  </tr>
+</table>
+
+
+**More example requests**
+
+```https://www.loc.gov/collections/herblock-cartoon-drawings/?fo=json&c=100```
+
+```https://www.loc.gov/photos/?fa=location:oklahoma```
+
+
+## Requesting a specific item
+
+### /item/{identifier}/?
+
+The best way to get at all of the fields related to a specific item is to look at search results and use the **id** field for that item, and put ```fo=json``` at the end. The id field is a URL; the path will vary from collection to collection. 
+
+Examples: 
+
+```https://www.loc.gov/item/ggb2006012811/?fo=json```
+
+```https://www.loc.gov/item/acd1999001521/PP/?fo=json```
+
+```https://www.loc.gov/item/ihas.200196396/?fo=json```
+
+{% include tip.html content="All item records that you find in search results have an **id** field (the URL for that item’s metadata). Some, but not all, collections have an **item_id** field, which contains just the unique identifier itself. Since not all collections have **item_id**, it’s better to rely on the **id** field and the URL it contains." %}
+
+{% include warning.html content="Only URLs in the **id** field that start with ```loc.gov/item``` or ```loc.gov/resource``` will return JSON format when you put ```fo=json``` at the end of the URL. If the **id** field starts with ```https://lccn.loc.gov/```, JSON format is not available because the item is a catalog record. If you are still interested in structured data for catalog records, you can put ```/marcxml``` on the end of the url and get the catalog record in MARCXML format." %}
+
+
+

--- a/docs/pages/apidocs/responses.md
+++ b/docs/pages/apidocs/responses.md
@@ -1,0 +1,368 @@
+---
+title: Responses
+keywords: responses, data, json, api 
+last_updated: Dec 19, 2017
+tags: 
+summary: "A response is the JSON you get back from your request to the loc.gov API. Because the API also provides data for the loc.gov website, there is a lot of data (e.g. breadcrumbs, facets) that are specifically for that purpose. This page focuses on the sections of the JSON response that are most useful for wokring with collections and items."
+sidebar: apidocs_sidebar
+permalink: responses.html
+folder: apidocs
+---
+
+## Search Results
+
+The top-level element ```results``` contains a list of items matching your query. Each item includes many elements, but some of the most useful ones are below. There is even more data available for each item if you request the ```/item/``` view. 
+
+<table>
+  <tr>
+    <td><strong>Field</strong></td>
+    <td><strong>Description</strong></td>
+    <td><strong>Type</strong></td>
+    <td><strong>Example</strong></td>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">original_format</td>
+    <td>The kind of object being described (not the digitized version).
+
+If the record is for an entire collection, that is included here.</td>
+    <td>array</td>
+    <td> [ "map" ]
+
+[ "photo, print, drawing", "collection"
+]
+</td>
+  </tr>
+  <tr>
+    <td>id</td>
+    <td>URL for the item, including its identifier. Always appears. </td>
+    <td>string</td>
+    <td>"http://www.loc.gov/item/2017645977/"</td>
+  </tr>
+  <tr>
+    <td>partof</td>
+    <td>Collections, divisions, and units in the Library of Congress. </td>
+    <td>array</td>
+    <td>["prints and photographs division",
+"lot 10526",
+"catalog"]</td>
+  </tr>
+  <tr>
+    <td>subject</td>
+    <td><p>List of subjects. These are broken-apart Library of Congress Subject Headings. Geography is not shown here, see the location element. </p>
+
+<p>For example, an item with the subject heading "Women -- Afghanistan -- Social conditions" will have [“social conditions",
+"women's rights"] in the subject element and “afghanistan” in the location element. </p>
+
+<p>For the full subject headings, request the JSON for the /item view</p></td>
+    <td>array</td>
+    <td>["public interest/advocacy",
+"history",
+"september 11 terrorist attacks"
+]
+</td>
+  </tr>
+  <tr>
+    <td>index</td>
+    <td>The index number of the results among all results. This starts with 1 and continues through all of the results in the whole set (not just this page). </td>
+    <td>integer</td>
+    <td>1</td>
+  </tr>
+  <tr>
+    <td>title</td>
+    <td>Title of the item</td>
+    <td>string</td>
+    <td>"Women Taxpayers; Women Voters"</td>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">online_format</td>
+    <td>Format available via the website</td>
+    <td>array</td>
+    <td>["web page"],
+
+["image","pdf"]
+
+</td>
+  </tr>
+  <tr>
+    <td>location</td>
+    <td>Place related to the item. 
+
+These are extracted from subject headings and other metadata, so there may be duplicates. </td>
+    <td>array</td>
+    <td>["earth (planet)",
+"planet", "earth"]
+
+["benin", "niger", 
+"niger", "benin"]
+
+</td>
+  </tr>
+  <tr>
+    <td>mime_type</td>
+    <td>Formats available for download</td>
+    <td>array</td>
+    <td>["image/gif",
+"video/mov",
+"video/mpeg",
+"application/x-video",
+"image/jpeg"]
+</td>
+  </tr>
+  <tr>
+    <td>digitized</td>
+    <td>Whether this item has been digitized. </td>
+    <td>boolean</td>
+    <td>true</td>
+  </tr>
+  <tr>
+    <td>description</td>
+    <td>Often includes a description of the original physical item. </td>
+    <td></td>
+    <td>["Correspondence. Typed letter regarding Scandinavian production rights to \"Kiss Me. Kate\" Courtesy of Cole Porter Trust (Copyright Notice)."]
+
+
+["1 photographic print. | Two Pueblo Indian women posed standing, full-length, New Mexico."]
+</td>
+  </tr>
+  <tr>
+    <td>date</td>
+    <td>Date of item creation. Could be a year or YYYY-MM-DD</td>
+    <td>string</td>
+    <td>"2002-08-08"
+
+“1910”</td>
+  </tr>
+  <tr>
+    <td>dates</td>
+    <td>List of dates related to the item. In ISO 8601 format, UTC.</td>
+    <td>array</td>
+    <td>["2001-01-01T00:00:00Z", "2001-10-30T00:00:00Z", "2001-12-15T00:00:00Z", "2002-01-01T00:00:00Z"]
+</td>
+  </tr>
+  <tr>
+    <td>language</td>
+    <td>Languages associated with the item</td>
+    <td>array</td>
+    <td>["english",
+"spanish"]
+</td>
+  </tr>
+  <tr>
+    <td>url</td>
+    <td>URL on the loc.gov website. 
+
+If the items is something in the library catalog, the URL will start with lccn.loc.gov. </td>
+    <td>string</td>
+    <td>https://www.loc.gov/item/2017711647/<br />
+  	//lccn.loc.gov/08030295</td>
+  </tr>
+  <tr>
+    <td>image_url</td>
+    <td>URLs for images in various sizes, if available. 
+
+If the item is not something that has an image (e.g. it’s a book that’s not digitized or an exhibit), the URL for the image might be for an icon image file. </td>
+    <td>array</td>
+    <td>["//cdn.loc.gov/service/pnp/bbc/<br />0000/0000/0004f_150px.jpg",]
+    </td>
+  </tr>
+</table>
+
+{% include warning.html content="If you're using the API from within the Library of Congress, you may have access to additional data. Notably, this may include URLs for images larger than thumbnails. These are only for use on-site at the Library of Congress, don't rely on that data being available off-site." %}
+
+## Example response
+
+
+A typical response is very long, with many elements that are intended for the website only. Shown below is just the ```item``` section of the response:
+
+```
+"item": {
+    "library_of_congress_control_number": "98688726",
+    "source_collection": [],
+    "display_offsite": true,
+    "contributors": [{
+            "g.w. & c. colton & co.": "https://www.loc.gov/search/?fa=contributor%3Ag.w.+%26+c.+colton+%26+co.&fo=json"
+        },
+        {
+            "new orleans, mobile, and chattanooga railroad": "https://www.loc.gov/search/?fa=contributor%3Anew+orleans%2C+mobile%2C+and+chattanooga+railroad&fo=json"
+        }
+    ],
+    "creator": "G.W. & C.B. Colton & Co.",
+    "access_restricted": false,
+    "site": [
+        "ammem",
+        "catalog"
+    ],
+    "original_format": [
+        "map"
+    ],
+    "genre": [],
+    "subject_headings": [
+        "New Orleans, Mobile, and Chattanooga Railroad",
+        "Railroads--United States--Maps",
+        "United States"
+    ],
+    "created_published": [
+        "New York, 1865."
+    ],
+    "extract_urls": [
+        "http://www.loc.gov/item/98688726#gmd.mar",
+        "http://lccn.loc.gov/98688726#catalog"
+    ],
+    "id": "http://www.loc.gov/item/98688726/",
+    "contents": [],
+    "subject": [
+        "new orleans, mobile, and chattanooga railroad",
+        "railroads",
+        "united states",
+        "maps"
+    ],
+    "index": 1,
+    "digital_id": [
+        "http://hdl.loc.gov/loc.gmd/g3701p.rr004750"
+    ],
+    "call_number": [
+        "G3701.P3 1865 .G15"
+    ],
+    "group": [
+        "gmd.mar",
+        "catalog",
+        "general-maps"
+    ],
+    "score": 11.276397,
+    "location_country": [
+        "united states"
+    ],
+    "title": "Map showing the New Orleans, Mobile & Chattanooga Railroad and its connections.",
+    "description": [
+        "Map of the eastern half of the United States showing drainage, cities and towns, counties, and the railroad network."
+    ],
+    "related_items": [],
+    "online_format": [
+        "image"
+    ],
+    "subjects": [{
+            "maps": "https://www.loc.gov/search/?fa=subject%3Amaps&fo=json"
+        },
+        {
+            "new orleans, mobile, and chattanooga railroad": "https://www.loc.gov/search/?fa=subject%3Anew+orleans%2C+mobile%2C+and+chattanooga+railroad&fo=json"
+        },
+        {
+            "railroads": "https://www.loc.gov/search/?fa=subject%3Arailroads&fo=json"
+        },
+        {
+            "united states": "https://www.loc.gov/search/?fa=subject%3Aunited+states&fo=json"
+        }
+    ],
+    "location": [{
+        "united states": "https://www.loc.gov/search/?fa=location%3Aunited+states&fo=json"
+    }],
+    "_version_": 1584611057109827600,
+    "type": [
+        "map"
+    ],
+    "mime_type": [
+        "image/gif",
+        "image/tiff",
+        "image/jpeg",
+        "image/jp2"
+    ],
+    "digitized": true,
+    "rights_advisory": [],
+    "medium": [
+        "map 53 x 83 cm."
+    ],
+    "reproduction_number": [],
+    "repository": [
+        "Library of Congress Geography and Map Division Washington, D.C. 20540-4650 USA dcu"
+    ],
+    "format": [{
+        "map": "https://www.loc.gov/search/?fa=original_format%3Amap&fo=json"
+    }],
+    "partof": [{
+            "count": 635,
+            "url": "https://www.loc.gov/collections/railroad-maps-1828-to-1900/?fo=json",
+            "title": "railroad maps, 1828-1900"
+        },
+        {
+            "count": 900,
+            "url": "https://www.loc.gov/collections/transportation-and-communication/?fo=json",
+            "title": "transportation and communication"
+        },
+        {
+            "count": 16205,
+            "url": "https://www.loc.gov/search/?fa=partof%3Ageography+and+map+division&fo=json",
+            "title": "geography and map division"
+        },
+        {
+            "count": 639861,
+            "url": "https://www.loc.gov/search/?fa=partof%3Aamerican+memory&fo=json",
+            "title": "american memory"
+        },
+        {
+            "count": 815225,
+            "url": "https://www.loc.gov/search/?fa=partof%3Acatalog&fo=json",
+            "title": "catalog"
+        }
+    ],
+    "timestamp": "2017-11-20T18:34:26.584000Z",
+    "campaigns": [],
+    "extract_timestamp": "2017-11-20T18:24:49.580000Z",
+    "date": "1865",
+    "shelf_id": "G3701.P3 1865 .G15",
+    "other_title": [],
+    "dates": [{
+        "1865": "https://www.loc.gov/search/?dates=1865%2F1865&fo=json"
+    }],
+    "language": [{
+        "english": "https://www.loc.gov/search/?fa=language%3Aenglish&fo=json"
+    }],
+    "rights": [
+        "<h2>\r\nRights and Access\r\n</h2>\r\n<p>The maps in the Map Collections materials were either  published prior to 1922, produced by the United States government, or both  (see catalogue records that accompany each map for information regarding  date of publication and source).  The Library of Congress is providing  access to these materials for educational and research purposes and is not  aware of any U.S. copyright protection (see Title 17 of the United States  Code) or any other restrictions in the Map Collection materials. </p>\r\n<p>Note that the written permission of the copyright owners and/or  other rights holders (such as publicity and/or privacy rights) is required  for distribution, reproduction, or other use of protected items beyond that  allowed by fair use or other statutory exemptions.  Responsibility for  making an independent legal assessment of an item and securing any necessary  permissions ultimately rests with persons desiring to use the item.</p>\r\n<p> More about <a href=\"//memory.loc.gov/ammem/copyrit2.html\"> American Memory, Copyright and other Restrictions</a></p>\r\n<p> Credit Line: Library of Congress, Geography and Map Division. </p>\r\n<p> For guidance about compiling full citations consult <a href=\"//memory.loc.gov/ammem/ndlpedu/start/cite/index.html\">Citing Electronic Sources</a> on the Learning Page. </p>\r\n"
+    ],
+    "url": "https://www.loc.gov/item/98688726/",
+    "notes": [
+        "Scale 1:3,168,000.",
+        "LC Railroad maps, 475",
+        "Description derived from published bibliography.",
+        "Inset: Map showing the relation of Mobile & N.O. to the ports of Mexico, Central America , and the W.I. 21 x 21 cm.",
+        "Available also through the Library of Congress Web site as a raster image."
+    ],
+    "control_number": "",
+    "summary": [
+        "Map of the eastern half of the United States showing drainage, cities and towns, counties, and the railroad network."
+    ],
+    "hassegments": false,
+    "image_url": [
+        "//cdn.loc.gov/service/gmd/gmd370/g3701/g3701p/rr004750.gif",
+        "//cdn.loc.gov/service/gmd/gmd370/g3701/g3701p/rr004750.gif#h=150&w=231",
+        "//tile.loc.gov/image-services/iiif/service:gmd:gmd370:g3701:g3701p:rr004750/full/pct:3.125/0/default.jpg#h=207&w=320",
+        "//tile.loc.gov/image-services/iiif/service:gmd:gmd370:g3701:g3701p:rr004750/full/pct:6.25/0/default.jpg#h=415&w=640",
+        "//tile.loc.gov/image-services/iiif/service:gmd:gmd370:g3701:g3701p:rr004750/full/pct:12.5/0/default.jpg#h=830&w=1280",
+        "//tile.loc.gov/image-services/iiif/service:gmd:gmd370:g3701:g3701p:rr004750/full/pct:25/0/default.jpg#h=1660&w=2560"
+    ],
+    "other_formats": [{
+            "link": "https://lccn.loc.gov/98688726/marcxml",
+            "label": "MARCXML Record"
+        },
+        {
+            "link": "https://lccn.loc.gov/98688726/mods",
+            "label": "MODS Record"
+        },
+        {
+            "link": "https://lccn.loc.gov/98688726/dc",
+            "label": "Dublin Core Record"
+        }
+    ],
+    "aka": [
+        "http://www.loc.gov/resource/g3701p.rr004750/",
+        "http://www.loc.gov/item/98688726/",
+        "http://hdl.loc.gov/loc.gmd/g3701p.rr004750",
+        "http://lccn.loc.gov/98688726"
+    ],
+    "contributor_names": [
+        "G.W. & C.B. Colton & Co.",
+        "New Orleans, Mobile, and Chattanooga Railroad."
+    ],
+    "access_advisory": []
+},
+```

--- a/docs/pages/apidocs/sitemaps.md
+++ b/docs/pages/apidocs/sitemaps.md
@@ -1,0 +1,38 @@
+---
+title: Sitemaps
+keywords: sitemaps, items, query, results, api 
+last_updated: Dec 19, 2017
+tags: 
+summary: "Sitemaps provide links to pages in a collection or items in a collection. Sitemaps are in XML."
+sidebar: apidocs_sidebar
+permalink: sitemaps.html
+folder: apidocs
+---
+
+Another way to get URLs for all of the items in a collection is to use collection-level sitemaps. Adding ```fo=sitemap``` instead of ```fo=json``` to a collection query will give you results in sitemap format. 
+
+**Example:**
+
+[http://www.loc.gov/collections/abraham-lincoln-papers/?c=1000&fo=sitemap](http://www.loc.gov/collections/abraham-lincoln-papers/?c=1000&fo=sitemap)
+
+```
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1/">
+  <url>
+    <loc>
+      http://www.loc.gov/collections/abraham-lincoln-papers/about-this-collection/
+    </loc>
+    <lastmod>2017-12-20T06:12:37.115000+00:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  ...
+  <url>
+    <loc>http://www.loc.gov/item/mal0019900/</loc>
+    <lastmod>2017-11-03T18:10:24.982000+00:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>
+```
+
+{% include tip.html content="Sitemaps are a quick way to get URLs for all of the items in a collection at once." %}


### PR DESCRIPTION
Reverting LibraryOfCongress/data-exploration#49 to reinstate the tutorial sidebar navigation